### PR TITLE
Simplify the makefile with `ember build -o`

### DIFF
--- a/src/tb-blog-post/Makefile
+++ b/src/tb-blog-post/Makefile
@@ -6,6 +6,6 @@ default:
 build:
 	mkdir -p dist
 	rm -rf dist/*
-	cd model-display && ember build && cd - && cp -pr model-display/dist/* dist/
+	cd model-display && ember build -o ../dist && cd -
 	elm-make elm/Main.elm --output dist/elm.js
 	cp -pr assets/* dist/


### PR DESCRIPTION
Instead of doing the extra work of a `cp` after building the Ember app, just use the `ember build` flag, `-o`/`--output-path`, to do it at build time.